### PR TITLE
Rewrite HTTP reporter to avoid goroutine leak / OOM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ _testmain.go
 *.prof
 
 .idea
+
+# vim
+*.sw*

--- a/reporter/http/http.go
+++ b/reporter/http/http.go
@@ -101,6 +101,7 @@ func (r *httpReporter) append(span *model.SpanModel) (newBatchSize int) {
 
 func (r *httpReporter) batchLoop() {
 	ticker := time.NewTicker(r.batchInterval)
+	defer func() { ticker.Close() }()
 	for {
 		select {
 		case <-r.fullBatch:

--- a/reporter/http/http.go
+++ b/reporter/http/http.go
@@ -109,6 +109,7 @@ func (r *httpReporter) batchLoop() {
 	for {
 		select {
 		case <-r.overflowC:
+			ticker.Stop()
 			ticker = time.NewTicker(r.batchInterval)
 			_ = r.sendBatch()
 		case <-ticker.C:


### PR DESCRIPTION
The original implementation creates a new goroutine for each call to `sendBatch`. When the server is down, each client will eventually create a new goroutine for every single incoming span, since the `currentBatchSize` can never decrease below the `batchSize`. The span mutex forces these goroutines to execute sequentially, so this amounts to a goroutine leak, causing each client to eventually OOM, based on the number of traces it sends.

The new implementation replaces the "new goroutine" behavior with a single goroutine, sending batches when requested in a loop. I attempted to preserve the original behavior of the old implementation:

* Sending a batch to the server doesn't block incoming spans from `spanC`
* A call to `sendBatch` is triggered as soon as `batchSize` messages are in the queue
* A call to `sendBatch` is triggered if it has been longer than `batchInterval` seconds since the last call to `sendBatch`
* When the reporter receives the quit signal from `r.quit`, one final call to `sendBatch` is triggered; its returned error is sent to the `r.shutdown` channel.